### PR TITLE
Initial docker env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:carbon
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json /usr/src/app/
+
+# Set required environment variables
+ENV NODE_ENV production
+
+# Install production modules
+RUN npm install --production
+
+# Copy app source code
+COPY dist /usr/src/app/dist/
+COPY public /usr/src/app/
+
+# Nothing secret here now, but this needs to be abstracted out before
+# anything is deployed
+COPY .env /usr/src/app/.env
+
+#Expose port and start application
+EXPOSE 3000
+CMD [ "npm", "start" ]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,24 @@
+FROM local/api
+
+
+# Redundant but when nodule modules contents change, it will force a
+# reinstall
+copy package.json package.json
+
+# Override the NODE_ENV environment variable to 'dev', in order to get required test packages
+ENV NODE_ENV dev
+
+# Get test packages
+RUN npm install
+
+# Install app dependencies
+COPY .babelrc .babelrc
+COPY .cfignore .cfignore
+COPY .env .env
+COPY .eslintrc.json .eslintrc.json
+COPY server server
+COPY test test
+
+#Expose port and start application
+EXPOSE 3030
+CMD [ "npm", "run", "test" ]

--- a/README.md
+++ b/README.md
@@ -62,9 +62,21 @@ or debug them
 npm run test:debug
 ```
 
+## Running in a local docker environment
+
+Also provided is a docker-compose based environment for integration test with the data store.  Three containers are created:
+
+  1. api - the core API container
+  2. mongo - the data store
+  3. test - runs through unit (and ideally integration tests) as the environment is being brought up.
+
+```shell
+npm run docker
+```
+
 ## Try It
 * Open you're browser to [http://localhost:3000](http://localhost:3000)
-* Invoke the `/examples` endpoint 
+* Invoke the `/examples` endpoint
   ```shell
   curl http://localhost:3000/api/v1/examples
   ```
@@ -110,4 +122,4 @@ cf push meso-challenge
 ```
 
 
-   
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3"
+services:
+  api:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    image: local/api
+    volumes:
+      - ".:/app"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mongo
+    links:
+      - mongo
+    environment:
+      # IMPORTANT!!!
+      # This needs to move out of checked in configuration before
+      # any secrets are added to this file.
+      - MONGO_DB=mongodb://mongo:27017/meso_api
+  mongo:
+    image: mongo:3.5
+    expose:
+      - "27017"
+    ports:
+      - "27017:27017"
+    command: mongod --port 27017 --bind_ip_all
+  test:
+    build:
+      dockerfile: Dockerfile.test
+      context: .
+    volumes:
+      - ".:/app"
+    ports:
+      - "3030:3030"
+    depends_on:
+      - mongo
+      - api
+    links:
+      - mongo
+    environment:
+      # IMPORTANT!!!
+      # This needs to move out of checked in configuration before
+      # any secrets are added to this file.
+      - MONGO_DB=mongodb://mongo:27017/meso_api_test
+
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "mocha --require @babel/register --exit",
     "test:debug": "mocha --require @babel/register --inspect-brk --exit",
     "lint": "eslint -c .eslintrc.json {server,test}/**",
-    "lint:fix": "eslint --fix -c .eslintrc.json {server,test}/**"
+    "lint:fix": "eslint --fix -c .eslintrc.json {server,test}/**",
+    "docker": "npm run compile && docker-compose up --build"
   },
   "dependencies": {
     "body-parser": "^1.18.2",


### PR DESCRIPTION
Added a basic docker environment to provide access to mongo and a basic integration environment.

Ideally this would be the bases for additional CI/CD checks.